### PR TITLE
feat: Auth Google Calendar API & Show, Add calendar event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 .env
 firebase.json
+google.json

--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const createError = require("http-errors");
 const app = express();
 
 const indexRouter = require("./routes/index");
+const calendarRouter = require("./routes/calendar");
 
 app.use(logger("dev"));
 app.use(express.json());
@@ -21,6 +22,7 @@ app.use(
 );
 
 app.use("/", indexRouter);
+app.use("/calendar", calendarRouter);
 
 app.use(function(req, res, next) {
   next(createError(404));

--- a/controllers/calendarController.js
+++ b/controllers/calendarController.js
@@ -1,0 +1,95 @@
+/* eslint-disable camelcase */
+const google = require("@googleapis/calendar");
+
+const catchAsync = require("../utils/catchAsync");
+const credentials = require("../google.json");
+
+const SCOPES = [
+  "https://www.googleapis.com/auth/calendar.readonly",
+  "https://www.googleapis.com/auth/calendar.events.readonly",
+  "https://www.googleapis.com/auth/calendar.events"
+];
+
+const {
+  client_secret,
+  client_id,
+  redirect_uris
+} = credentials.web;
+
+const oAuth2Client = new google.auth.OAuth2(
+  client_id,
+  client_secret,
+  redirect_uris[2]
+);
+
+exports.googleCalendarAuth = catchAsync((req, res, next) => {
+  const authUrl = oAuth2Client.generateAuthUrl({
+    access_type: "offline",
+    scope: SCOPES,
+  });
+
+  res.redirect(authUrl);
+});
+
+exports.getTodayEvent = catchAsync((req, res, next) => {
+  const { code } = req.query;
+
+  const startDate = new Date();
+  const endDate = new Date();
+
+  startDate.setHours(0, 0, 0);
+  endDate.setHours(23, 59, 59);
+
+  oAuth2Client.getToken(code, (err, token) => {
+    oAuth2Client.setCredentials(token);
+
+    const calendar = google.calendar({version: "v3", auth: oAuth2Client});
+
+    calendar.events.list({
+      calendarId: "primary",
+      timeMax: endDate,
+      timeMin: startDate,
+    }, (err, result) => {
+      res.json({
+        result: "success",
+        todayEvent: result.data.items,
+      });
+    });
+  });
+});
+
+exports.createEvent = catchAsync(async (req, res, next) => {
+  const { code } = req.query;
+
+  const startDate = new Date();
+  const endDate = new Date();
+
+  const sampleRequestBody = {
+    "summary": "Calendar Test",
+    "start": {
+      "dateTime": startDate,
+      "timeZone": "Asia/Seoul",
+    },
+    "end": {
+      "dateTime": endDate,
+      "timeZone": "Asia/Seoul",
+    },
+  };
+
+  oAuth2Client.getToken(code, (err, token) => {
+    oAuth2Client.setCredentials(token);
+
+    const calendar = google.calendar({version: "v3", auth: oAuth2Client});
+
+    calendar.events.insert({
+      calendarId: "primary",
+      resource: sampleRequestBody,
+    }, (err, result) => {
+      if (result.data) {
+        res.json({
+          result: "success",
+        });
+      }
+    });
+  });
+});

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const router = express.Router();
+
+const {
+  getTodayEvent,
+  createEvent,
+  googleCalendarAuth,
+} = require("../controllers/calendarController");
+
+router.get("/auth", googleCalendarAuth);
+router.get("/event", getTodayEvent);
+router.get("/insert/event", createEvent);
+
+module.exports = router;


### PR DESCRIPTION
# Description
- Conncect
  - Google Calendar API
- Flow : calendar controller
  - 구글 캘린더의 기능을 사용할 수 있게 하는 권한을 설정해준다. (SCOPES)
  - OAuth2를 사용해 구글 API의 인증을 설정한다.
    - redirect_uris : 현재 PR 시점에서 구글 캘린더 이벤트 추가 라우터의 주소를 담고 있다.
  - googleCalendarAuth
    - 구글 API 인증 주소를 생성한 후 인증 주소로 redirect 한다.
  - getTodayEvent
    - 인증 주소를 통해 인증에 성공하면 접속되는 callback 주소이다.
    - 오늘 날짜의 calendar event를 불러올 startDate와 endDate의 시간을 설정해준다.
    - callback 주소의 query 중 하나인 code를 사용해 token을 받아온다.
    - OAuth2의 credentials에 token을 추가 설정해준다.
    - 구글 캘린더 API에 사용할 버전과 OAuth2 인증을 설정해준다.
    - calendar event를 불러올 parameters를 설정해준다.
      - calendarId : 현재 로그인한 사용자
      - timeMax : 필터링 될 종료 날짜
      - timeMin : 필터링 될 시간 날짜
    - 클라이언트로 오늘 날짜의 calendar event를 전달해준다.
  - createEvent
    - 위의 getTodayEvent의 플로우와 비슷하나 parameters 설정과 클라이언트 전달값이 다르다.
    - calendar event를 저장할 parameters를 설정해준다.
      - calendarId : 현재 로그인한 사용자
      - resource : calendar event의 생성 정보
        - summary : event 제목
        - start : event 시작 시간으로 설정할 dateTime과 timeZone을 설정할 수 있다.
        - end : event 종료 시간으로 설정할 dateTime과 timeZone을 설정할 수 있다.
    - 클라이언트로 성공 여부를 전달해준다.

# Type
- [x] New feature
- [ ] Refactor
- [ ] Minor change
- [ ] Design
- [ ] Fix bug

# Canban Link
[[BE] Calendar : Read](https://delicious-astrodon-c22.notion.site/BE-Calendar-Read-65230841a0764a2ca811cb845341fa45)
[[BE] Calendar : Create](https://delicious-astrodon-c22.notion.site/BE-Calendar-Create-2a06ae28f1914dc2aa0d971bdd20768c)
…

# Check List
- [x]  커밋하기 전에 자신의 코드를 점검했는가
- [x]  이해하기 어려운 코드에 대한 언급을 하였는가
- [x]  문서의 내용과 일치하는 작업을 했는가
- [x]  나의 코드가 새로운 문제를 발생시키지 않는가

# 기타 사항
Google Calendar API의 플로우를 학습하는데 오래 걸렸다. 클라이언트와 연결 시 인증 문제로 넘어갈 수 있으니 리팩토링이 필수다.